### PR TITLE
Fixed template not found when access with root URL

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,15 +1,18 @@
-const express = require("express");
-const Tailor = require("node-tailor");
-const { fetchTemplate, filterRequestHeaders } = require("./tailor");
+const express = require('express');
+const Tailor = require('node-tailor');
+const { fetchTemplate, filterRequestHeaders } = require('./tailor');
 
 const tailor = new Tailor({
   fetchTemplate,
-  filterRequestHeaders
+  filterRequestHeaders,
 });
 
 const app = express();
-
-app.use(express.static("dist"));
+app.get('/', function(req, res, next) {
+  req.url = '/index';
+  next();
+});
+app.use(express.static('dist'));
 
 app.use(tailor.requestHandler);
 


### PR DESCRIPTION
- Fixed "template not found" when access with http://localhost:3000
- It will render the /index template by default.